### PR TITLE
refactor: adds touches to css

### DIFF
--- a/src/component/Favorites/Favorites.css
+++ b/src/component/Favorites/Favorites.css
@@ -1,16 +1,12 @@
 .favorite-main {
   display: flex;
   flex-direction: column;
-  /* align-items: center;
-  justify-content: center; */
-  /* height: 100vh; */
   background: -moz-linear-gradient(top, #BBEAEA 0%, #D1E4D0 100%);
   background: -webkit-linear-gradient(top, #BBEAEA 0%, #D1E4D0 100%);
   background: linear-gradient(to bottom, #BBEAEA 0%, #D1E4D0 100%);
 }
 
 .favorite-animal-pic {
-  /* max-width: 250px; */
   min-width: 100%;
   min-height: 100%;
   object-fit: cover;
@@ -23,14 +19,14 @@
 }
 
 .animal-list {
-  margin-top: 11vh; 
+  margin-top: 11vh;
+  min-height: 89vh;
 }
 
 .favorite-animal-name {
   margin: 0;
   font-weight: bold;
   font-size: 1.5rem ;
-  /* color: white; */
 }
 
 .favorite-header {
@@ -47,7 +43,6 @@
 
 .favorite-index {
   margin: 2em;
-  /* border: 2px solid black; */
   padding: 1em;
   border-radius: 8px;
   display: flex;
@@ -55,14 +50,12 @@
   align-items: center;
   box-shadow: 0px 4px 8px black;
   transition: transform 0.3s, box-shadow 0.3s;
-  /* background-color: white; */
   background-color: rgb(229, 169, 101);
-  /* background-color: #fbb02d; */
   max-width: 250px;
   text-align: center;
   justify-content: space-evenly;  
   gap: 0.5rem ;
-  /* max-height: 500px; */
+
 }
 
 .favorite-index:hover {
@@ -71,8 +64,6 @@
 }
 
 .image-container {
-  /* background-color: rgb(79, 44, 44); */
-  /* height: 100%; */
   display: flex;
   align-items: center;
   width: 100%;
@@ -81,15 +72,11 @@
   object-fit: cover;
   object-position: center;
   overflow: hidden;
- 
 }
 
 .animal-info {
   display: flex;
   align-items: center;
   justify-content: center;
-  /* padding: 1em; */
   font-size: 1rem;
 }
-
-/* Maybe add a favorites counter? */

--- a/src/component/GamePlay/GamePlay.css
+++ b/src/component/GamePlay/GamePlay.css
@@ -20,19 +20,19 @@
 }
 
 .facts-section {
-  max-width: 55vw;
-  font-size: 2.3vh;
+  max-width: 50vw;
+  font-size: 2.1vh;
 }
 
 @media screen and (max-width: 1404px) {
   .facts-section {
-    font-size: 2vh;
+    font-size: 2.3vh;
   }
 }
 
 @media screen and (max-width: 1016px) {
   .facts-section {
-    font-size: 1.5vh;
+    font-size: 2vh;
     width: 70vw;
   }
 }
@@ -40,23 +40,19 @@
 @media screen and (max-width: 800px) {
   .animal-container {
     flex-direction: column;
+    align-items: center;
   }
 
   .animal-pic {
-    height: 100%;
-    width: 60%;
+    max-width: 37.5em;
+    max-height: 25em;
+  }
+
+  .facts-section {
+    width: 90vw; 
+    max-width: none;
   }
 }
-
-/* .favorite-button {
-  bottom: 200px;
-  height: 100px;
-  height: 70px;
-  width: 100px;
-  width: 70px;
-  cursor: pointer;
-  border: 2px solid #fbb02d;
-} */
 
 .clickables {
   display: flex;
@@ -72,7 +68,7 @@
 
 .animal-pic { 
   max-width: 37.5em;
-  max-height: 37.5em;
+  max-height: 25em;
   border-radius: 8px;
 }
 
@@ -89,6 +85,7 @@
   cursor: pointer;
   margin: 10px;
   font-family: inherit;
+  transition: transform 0.5s ease, box-shadow 0.5s ease;
 }
 
 .eat-me-button:hover {
@@ -115,7 +112,7 @@
   padding: 20px;
   border-radius: 10px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-  max-width: 500px;
+  max-width: 550px;
 }
 
 .predators-container {
@@ -130,7 +127,6 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
-  border-radius: 8px;
   align-items: center;
 }
 
@@ -144,6 +140,15 @@
   border-radius: 10px;
   object-fit: cover;
   object-position: top;
+  transition: transform 0.5s ease, box-shadow 0.5s ease;
+  box-shadow: 0px 0px 10px black;
+}
+
+.predator-image:hover
+{
+  transform: scale(1.1);
+  box-shadow: 0px 0px 20px lightskyblue;
+  cursor: pointer;
 }
 
 .love{
@@ -153,7 +158,6 @@
   width: 100px;
   width: 70px;
   cursor: pointer;
-  /* border: 2px solid #fbb02d; */
 
   display: flex;
   align-items: center;

--- a/src/component/home/home.css
+++ b/src/component/home/home.css
@@ -7,6 +7,7 @@
   background: -moz-linear-gradient(top, #BBEAEA 0%, #D1E4D0 100%);
   background: -webkit-linear-gradient(top, #BBEAEA 0%, #D1E4D0 100%);
   background: linear-gradient(to bottom, #BBEAEA 0%, #D1E4D0 100%);
+  box-sizing: border-box; 
 }
 
 .home-screen {
@@ -26,4 +27,6 @@
   font-size: x-large;
   text-align: center;
   background-color: #fbb02d;
+  margin: 0;
+  padding: 0;
 }


### PR DESCRIPTION
This PR add changes to the css

- Gameplay for rabbit now fits onto one regular sized mac screen without scrolling to the eat me button
- empty favorites page has background color
- modal has more styling, button animations, and cursor to pointer on things that can be clicked
- animal image and facts are center under 800px screen size
- adjusted some font sizes
- deleted some commented out code